### PR TITLE
feat: Rename package to live under `@cerbos` scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,19 @@ To use the Cerbos JavaScript client library, you'll need:
 ## Installation
 
 ```sh
-$ npm i cerbos
+$ npm i @cerbos/sdk
 ```
 
 or
 
 ```
-$ yarn add cerbos
+$ yarn add @cerbos/sdk
 ```
 
 ## Usage
 
 ```js
-import { Cerbos } from "cerbos";
+import { Cerbos } from "@cerbos/sdk";
 
 const cerbos = new Cerbos({
   hostname: "http://localhost:9090", // The Cerbos PDP instance

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cerbos",
+  "name": "@cerbos/sdk",
   "version": "0.4.0",
   "homepage": "https://cerbos.dev",
   "description": "Cerbos helps you super-charge your authorization implementation by writing context-aware access control policies for your application resources.",


### PR DESCRIPTION
#### Description

This PR renames the package from `cerbos` to `@cerbos/sdk` so that it is namespaced under [our npm organization](https://www.npmjs.com/org/cerbos).