### PR TITLE
chore(deps): fix commit message for development dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,4 @@ updates:
     commit-message:
       include: scope
       prefix: "chore(deps): "
+      prefix-development: "chore(deps-dev): "


### PR DESCRIPTION
#### Description

The commit message is currently a bit janky, e.g. `chore(deps): (deps-dev): bump eslint-plugin-jest from 24.7.0 to 26.1.1`. Hopefully this fixes it 😅 