### PR TITLE
chore(deps): allow dependabot to figure out the commit message format itself

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,3 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    commit-message:
-      include: scope
-      prefix: "chore(deps): "
-      prefix-development: "chore(deps-dev): "


### PR DESCRIPTION
#### Description

#16 didn't work because [apparently there is a limit to the prefix length](https://github.com/cerbos/cerbos-sdk-node/runs/5291348224) 🤷 

Dependabot should figure out the message format from the latest commits on main so hopefully it will Just Work™️  without explicit configuration